### PR TITLE
Use resolved name

### DIFF
--- a/_data/projects/open_source.yml
+++ b/_data/projects/open_source.yml
@@ -1,4 +1,4 @@
 - title: M-Pesa Gem (WIP)
   url: https://github.com/itsmrwave/mpesa-gem
 - title: Pesapal Gem
-  url: https://itsmrwave.github.io/pesapal-gem
+  url: http://kingori.co/pesapal-gem/


### PR DESCRIPTION
Because Turbolinks doesn't seem to play well with the resulting redirect (which this results to).